### PR TITLE
Fix Navigation isue

### DIFF
--- a/samples/Xamarin.Forms/SliderView/Droid/SliderViewRenderer.cs
+++ b/samples/Xamarin.Forms/SliderView/Droid/SliderViewRenderer.cs
@@ -50,7 +50,6 @@ namespace Slider.Droid
 
 		protected override void Dispose (bool disposing)
 		{
-			base.Dispose (disposing);
 			//If CurrentView is a Layout, then we need to remove the Touch event
 			if (_sliderView.CurrentView is Layout) {
 				//This viewgroup contains the ViewScreen that we need to get at child 0
@@ -64,7 +63,8 @@ namespace Slider.Droid
 			Touch -= HandleGenericMotion;
 			//Call the garbage collection to make sure the BitMaps are cleaned up
 			GC.Collect ();
-		}
+            base.Dispose(disposing);
+        }
 
 		async void HandleGenericMotion (object sender, TouchEventArgs e)
 		{


### PR DESCRIPTION
When navigating back to the main page when seeing the
RandomAbsoluteLayout in the SliderView. The application crashes. This is
becaouse the base.Dipose in the Dispose method of the SliderViewRenderer
for android causes the viewgroup.GetChildAt(0) to return null